### PR TITLE
better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "sane adjacently tagged enum deserialization (with untagged varian
 version = "0.1.2"
 edition = "2021"
 license = "MIT"
-homepage = "https://github.com/muttleyxd/serde_sated"
+repository = "https://github.com/muttleyxd/serde_sated"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).
